### PR TITLE
Remove unnecessary left outer join from the janus backend SQL queries

### DIFF
--- a/src/db/janus_backend.rs
+++ b/src/db/janus_backend.rs
@@ -247,10 +247,8 @@ const MOST_LOADED_SQL: &str = r#"
             FROM agent AS a
             INNER JOIN agent_connection AS ac
             ON ac.agent_id = a.id
-            LEFT JOIN rtc
-            ON rtc.id = ac.rtc_id
             LEFT JOIN rtc_writer_config AS rwc
-            ON rwc.rtc_id = rtc.id
+            ON rwc.rtc_id = ac.rtc_id
             GROUP BY a.room_id
         ),
         active_room AS (
@@ -317,10 +315,8 @@ const LEAST_LOADED_SQL: &str = r#"
             FROM agent AS a
             INNER JOIN agent_connection AS ac
             ON ac.agent_id = a.id
-            LEFT JOIN rtc
-            ON rtc.id = ac.rtc_id
             LEFT JOIN rtc_writer_config AS rwc
-            ON rwc.rtc_id = rtc.id
+            ON rwc.rtc_id = ac.rtc_id
             GROUP BY a.room_id
         ),
         active_room AS (
@@ -390,10 +386,8 @@ const FREE_CAPACITY_SQL: &str = r#"
             FROM agent AS a
             INNER JOIN agent_connection AS ac
             ON ac.agent_id = a.id
-            LEFT JOIN rtc
-            ON rtc.id = ac.rtc_id
             LEFT JOIN rtc_writer_config AS rwc
-            ON rwc.rtc_id = rtc.id
+            ON rwc.rtc_id = ac.rtc_id
             GROUP BY a.room_id
         ),
         active_room AS (
@@ -514,10 +508,8 @@ WITH
         FROM agent AS a
         INNER JOIN agent_connection AS ac
         ON ac.agent_id = a.id
-        LEFT JOIN rtc
-        ON rtc.id = ac.rtc_id
         LEFT JOIN rtc_writer_config AS rwc
-        ON rwc.rtc_id = rtc.id
+        ON rwc.rtc_id = ac.rtc_id
         GROUP BY a.room_id
     ),
     active_room AS (


### PR DESCRIPTION
Query execution plan before this change:
```
                                                                    QUERY PLAN                                                                     
----------------------------------------------------------------------------------------------------------------------------------------------------
 HashAggregate  (cost=2270.69..2293.57 rows=1831 width=48) (actual time=28.678..28.700 rows=56 loops=1)
   Group Key: a.room_id
   ->  Hash Join  (cost=2034.35..2232.31 rows=3838 width=24) (actual time=25.265..27.452 rows=3836 loops=1)
         Hash Cond: (ac.agent_id = a.id)
         ->  Hash Right Join  (cost=1776.42..1964.29 rows=3838 width=24) (actual time=22.096..23.500 rows=3836 loops=1)
               Hash Cond: (rwc.rtc_id = rtc.id)
               ->  Seq Scan on rtc_writer_config rwc  (cost=0.00..164.76 rows=4776 width=24) (actual time=0.009..0.716 rows=4777 loops=1)
               ->  Hash  (cost=1728.44..1728.44 rows=3838 width=32) (actual time=21.912..21.914 rows=3836 loops=1)
                     Buckets: 4096  Batches: 1  Memory Usage: 272kB
                     ->  Hash Left Join  (cost=1603.99..1728.44 rows=3838 width=32) (actual time=20.449..21.523 rows=3836 loops=1)
                           Hash Cond: (ac.rtc_id = rtc.id)
                           ->  Seq Scan on agent_connection ac  (cost=0.00..114.38 rows=3838 width=32) (actual time=0.012..0.455 rows=3836 loops=1)
                           ->  Hash  (cost=1163.44..1163.44 rows=35244 width=16) (actual time=20.363..20.364 rows=35782 loops=1)
                                 Buckets: 65536  Batches: 1  Memory Usage: 2190kB
                                 ->  Seq Scan on rtc  (cost=0.00..1163.44 rows=35244 width=16) (actual time=0.008..9.549 rows=35782 loops=1)
         ->  Hash  (cost=204.08..204.08 rows=4308 width=32) (actual time=3.154..3.155 rows=4308 loops=1)
               Buckets: 8192  Batches: 1  Memory Usage: 334kB
               ->  Seq Scan on agent a  (cost=0.00..204.08 rows=4308 width=32) (actual time=0.007..1.736 rows=4308 loops=1)
 Planning Time: 1.199 ms
 Execution Time: 28.787 ms
(20 rows)
```

After:
```
                                                                QUERY PLAN                                                                
------------------------------------------------------------------------------------------------------------------------------------------
 HashAggregate  (cost=566.72..582.28 rows=1245 width=48) (actual time=8.709..8.738 rows=20 loops=1)
   Group Key: a.room_id
   ->  Hash Left Join  (cost=459.28..554.27 rows=1245 width=24) (actual time=5.802..7.468 rows=1210 loops=1)
         Hash Cond: (ac.rtc_id = rwc.rtc_id)
         ->  Hash Join  (cost=234.62..326.34 rows=1245 width=32) (actual time=2.484..3.672 rows=1210 loops=1)
               Hash Cond: (ac.agent_id = a.id)
               ->  Seq Scan on agent_connection ac  (cost=0.00..88.45 rows=1245 width=32) (actual time=0.009..0.490 rows=1210 loops=1)
               ->  Hash  (cost=193.72..193.72 rows=3272 width=32) (actual time=2.460..2.461 rows=3222 loops=1)
                     Buckets: 4096  Batches: 1  Memory Usage: 234kB
                     ->  Seq Scan on agent a  (cost=0.00..193.72 rows=3272 width=32) (actual time=0.006..1.424 rows=3222 loops=1)
         ->  Hash  (cost=164.85..164.85 rows=4785 width=24) (actual time=3.300..3.301 rows=4786 loops=1)
               Buckets: 8192  Batches: 1  Memory Usage: 326kB
               ->  Seq Scan on rtc_writer_config rwc  (cost=0.00..164.85 rows=4785 width=24) (actual time=0.011..1.857 rows=4786 loops=1)
 Planning Time: 0.719 ms
 Execution Time: 8.812 ms
(15 rows)
```