### PR TITLE
Fix clippy warning

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -5,7 +5,7 @@ where
     T: serde::Serialize,
 {
     let s = serde_json::to_string(val)?;
-    let b = base64::encode(&s);
+    let b = base64::encode(s);
     Ok(b)
 }
 


### PR DESCRIPTION
```
warning: the borrowed expression implements the required traits
 --> src/util.rs:8:28
  |
8 |     let b = base64::encode(&s);
  |                            ^^ help: change this to: `s`
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
  = note: `#[warn(clippy::needless_borrow)]` on by default
```